### PR TITLE
Enable secure saved object in Kibana for Alerting

### DIFF
--- a/kibana.tf
+++ b/kibana.tf
@@ -12,11 +12,11 @@ module "kibana" {
   cf_domain    = data.cloudfoundry_domain.app_domain.name
   name_postfix = local.postfix
 
-  environment = {
+  environment = merge({
     ELASTICSEARCH_HOSTS    = "https://${cloudfoundry_service_key.elastic_key.credentials.hostname}:${cloudfoundry_service_key.elastic_key.credentials.port}"
     ELASTICSEARCH_USERNAME = cloudfoundry_service_key.elastic_key.credentials.username
     ELASTICSEARCH_PASSWORD = cloudfoundry_service_key.elastic_key.credentials.password
-  }
-
-
+  },var.kibana_encryption_key!="" ?{
+    XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY = var.kibana_encryption_key
+  }:{})
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,9 @@ variable "kibana_image" {
   default     = "docker.elastic.co/kibana/kibana:7.7.1"
   type        = string
 }
+variable "kibana_encryption_key" {
+  description = "Encryption key to enable alerts in Kibana"
+  default     = ""
+  type        = string
+  # example: 2751772b-5e27-41f4-adf7-b7322260e5f8
+}


### PR DESCRIPTION
Alerts in Kibana is disabled by default. This will be enabled only when an encryption key is set to secure saved objects in Kibana. This is done by adding XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY  environment variable with a custom 32 char string. Added this changes to Kibana.tf